### PR TITLE
fix regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const processFiles = (error, filePaths) => {
   filePaths.forEach(filePath => {
     const data = fs.readFileSync(filePath, {encoding: 'utf-8'});
 
-    const regex = /[\;|\s]\_[\_|n|x]\(\s*(.*?)\s*\)|\[\"\_[\_|n|x]\"\]\)\((.*?)\)/gm;
+    const regex = /\b\_[\_|n|x]\(\s*(.*?)\s*\)|\[\"\_[\_|n|x]\"\]\)\((.*?)\)/gm;
     let m;
 
     while ((m = regex.exec(data)) !== null) {


### PR DESCRIPTION
In some cases, my organization needs to generate translations from minified and mangled JS files.  We can get around the mangling by making `__` reserved in the build, but the matcher regex still isn't working because it requires `[\s:]` preceding the translation call. This update would change that requirement to a word boundary (`\b`).